### PR TITLE
feature: oxo-ios-ben3 ShareNote - iOS Stored XSS

### DIFF
--- a/mobile/ios/oxo-ios-ben3/README.md
+++ b/mobile/ios/oxo-ios-ben3/README.md
@@ -1,0 +1,35 @@
+# oxo-ios-ben3 ShareNote - iOS Stored XSS
+
+## Challenge Details
+
+### Description
+A seemingly innocuous note-sharing application for iOS, "ShareNote," allows users to create notes from HTML content or import `.html` files from other applications. The application fails to sanitize user-controlled HTML input before rendering it in a privileged WebView context, creating a classic injection vulnerability. Can your tool identify the data exfiltration path?
+
+### Vulnerability Type and Category
+- **Type:** Stored Cross-Site Scripting (XSS)
+- **Category:** Injection
+
+### Weakness (CWE)
+- **CWE-79:** Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
+
+### Platform
+iOS (Swift/SwiftUI)
+
+### Difficulty
+Medium
+
+## Vulnerability Overview
+The application's `NoteDetailView` renders note content by directly passing user-controlled input (from either manual creation or file import) to a `WKWebView`'s `loadHTMLString` method without any sanitization. This allows for the execution of arbitrary JavaScript code in the context of the application. The provided proof-of-concept payload demonstrates data exfiltration by leveraging an image's `onerror` event to send the device's User-Agent string to a remote server controlled by the attacker.
+
+## Exploitation Vectors
+1.  **File Import:** The app is registered to handle `.html` files. A malicious HTML file shared from Mail, Messages, or Safari will be imported and stored as a note.
+2.  **Manual Creation:** The in-app note editor allows users to paste or write raw HTML content, which is stored without validation.
+
+## Build Instructions
+This is a standard Xcode project. Open `ShareNote.xcodeproj` and build for the iOS Simulator or a physical device.
+
+1.  **Ensure your dummy server is running** to capture exfiltrated data (see `Server Setup` below).
+2.  **Run the app** in the simulator (`Cmd + R`).
+3.  **Trigger the vulnerability** by either:
+    - Tapping the `+` button, creating a new note with HTML/JS content, saving it, and opening it.
+    - Importing a malicious `.html` file into the app from another application (e.g., Safari, Files).

--- a/mobile/ios/oxo-ios-ben3/src/sharenote/.gitignore
+++ b/mobile/ios/oxo-ios-ben3/src/sharenote/.gitignore
@@ -1,0 +1,20 @@
+# Xcode user-specific files
+*.xcuserstate
+*.xcuserdatad/
+
+# Workspace files (except the essential one)
+.xcworkspace/
+*.xcworkspace
+!*.xcworkspace/contents.xcworkspacedata
+
+# Scheme files
+xcschemes/
+*.xcscheme
+!default.xcscheme
+
+# Build generated files
+build/
+DerivedData/
+
+# macOS metadata
+.DS_Store

--- a/mobile/ios/oxo-ios-ben3/src/sharenote/sharenote.xcodeproj/project.pbxproj
+++ b/mobile/ios/oxo-ios-ben3/src/sharenote/sharenote.xcodeproj/project.pbxproj
@@ -1,0 +1,369 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		4AD9C7D32E6987D300DE5C80 /* sharenoteApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD9C7D22E6987D300DE5C80 /* sharenoteApp.swift */; };
+		4AD9C7D52E6987D300DE5C80 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD9C7D42E6987D300DE5C80 /* ContentView.swift */; };
+		4AD9C7D72E6987D400DE5C80 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4AD9C7D62E6987D400DE5C80 /* Assets.xcassets */; };
+		4AD9C7DA2E6987D400DE5C80 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4AD9C7D92E6987D400DE5C80 /* Preview Assets.xcassets */; };
+		4AD9C7E12E6987E500DE5C80 /* Note.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD9C7E02E6987E500DE5C80 /* Note.swift */; };
+		4AD9C7E32E6987F800DE5C80 /* NoteStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD9C7E22E6987F800DE5C80 /* NoteStore.swift */; };
+		4AD9C7E52E69882A00DE5C80 /* NewNoteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD9C7E42E69882A00DE5C80 /* NewNoteView.swift */; };
+		4AD9C7E72E69884A00DE5C80 /* NoteDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD9C7E62E69884A00DE5C80 /* NoteDetailView.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		4AD9C7CF2E6987D300DE5C80 /* sharenote.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = sharenote.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		4AD9C7D22E6987D300DE5C80 /* sharenoteApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = sharenoteApp.swift; sourceTree = "<group>"; };
+		4AD9C7D42E6987D300DE5C80 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		4AD9C7D62E6987D400DE5C80 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		4AD9C7D92E6987D400DE5C80 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		4AD9C7E02E6987E500DE5C80 /* Note.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Note.swift; sourceTree = "<group>"; };
+		4AD9C7E22E6987F800DE5C80 /* NoteStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteStore.swift; sourceTree = "<group>"; };
+		4AD9C7E42E69882A00DE5C80 /* NewNoteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewNoteView.swift; sourceTree = "<group>"; };
+		4AD9C7E62E69884A00DE5C80 /* NoteDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteDetailView.swift; sourceTree = "<group>"; };
+		4AD9C7E82E69888800DE5C80 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		4AD9C7CC2E6987D300DE5C80 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		4AD9C7C62E6987D300DE5C80 = {
+			isa = PBXGroup;
+			children = (
+				4AD9C7D12E6987D300DE5C80 /* sharenote */,
+				4AD9C7D02E6987D300DE5C80 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		4AD9C7D02E6987D300DE5C80 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				4AD9C7CF2E6987D300DE5C80 /* sharenote.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		4AD9C7D12E6987D300DE5C80 /* sharenote */ = {
+			isa = PBXGroup;
+			children = (
+				4AD9C7E82E69888800DE5C80 /* Info.plist */,
+				4AD9C7D22E6987D300DE5C80 /* sharenoteApp.swift */,
+				4AD9C7D42E6987D300DE5C80 /* ContentView.swift */,
+				4AD9C7E02E6987E500DE5C80 /* Note.swift */,
+				4AD9C7E22E6987F800DE5C80 /* NoteStore.swift */,
+				4AD9C7E42E69882A00DE5C80 /* NewNoteView.swift */,
+				4AD9C7E62E69884A00DE5C80 /* NoteDetailView.swift */,
+				4AD9C7D62E6987D400DE5C80 /* Assets.xcassets */,
+				4AD9C7D82E6987D400DE5C80 /* Preview Content */,
+			);
+			path = sharenote;
+			sourceTree = "<group>";
+		};
+		4AD9C7D82E6987D400DE5C80 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				4AD9C7D92E6987D400DE5C80 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		4AD9C7CE2E6987D300DE5C80 /* sharenote */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4AD9C7DD2E6987D400DE5C80 /* Build configuration list for PBXNativeTarget "sharenote" */;
+			buildPhases = (
+				4AD9C7CB2E6987D300DE5C80 /* Sources */,
+				4AD9C7CC2E6987D300DE5C80 /* Frameworks */,
+				4AD9C7CD2E6987D300DE5C80 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = sharenote;
+			productName = sharenote;
+			productReference = 4AD9C7CF2E6987D300DE5C80 /* sharenote.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		4AD9C7C72E6987D300DE5C80 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1540;
+				LastUpgradeCheck = 1540;
+				TargetAttributes = {
+					4AD9C7CE2E6987D300DE5C80 = {
+						CreatedOnToolsVersion = 15.4;
+					};
+				};
+			};
+			buildConfigurationList = 4AD9C7CA2E6987D300DE5C80 /* Build configuration list for PBXProject "sharenote" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 4AD9C7C62E6987D300DE5C80;
+			productRefGroup = 4AD9C7D02E6987D300DE5C80 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				4AD9C7CE2E6987D300DE5C80 /* sharenote */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		4AD9C7CD2E6987D300DE5C80 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4AD9C7DA2E6987D400DE5C80 /* Preview Assets.xcassets in Resources */,
+				4AD9C7D72E6987D400DE5C80 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		4AD9C7CB2E6987D300DE5C80 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4AD9C7D52E6987D300DE5C80 /* ContentView.swift in Sources */,
+				4AD9C7E32E6987F800DE5C80 /* NoteStore.swift in Sources */,
+				4AD9C7D32E6987D300DE5C80 /* sharenoteApp.swift in Sources */,
+				4AD9C7E72E69884A00DE5C80 /* NoteDetailView.swift in Sources */,
+				4AD9C7E52E69882A00DE5C80 /* NewNoteView.swift in Sources */,
+				4AD9C7E12E6987E500DE5C80 /* Note.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		4AD9C7DB2E6987D400DE5C80 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		4AD9C7DC2E6987D400DE5C80 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		4AD9C7DE2E6987D400DE5C80 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"sharenote/Preview Content\"";
+				DEVELOPMENT_TEAM = HTM74555ND;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = sharenote/Info.plist;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.notepro.sharenote;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		4AD9C7DF2E6987D400DE5C80 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"sharenote/Preview Content\"";
+				DEVELOPMENT_TEAM = HTM74555ND;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = sharenote/Info.plist;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.notepro.sharenote;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		4AD9C7CA2E6987D300DE5C80 /* Build configuration list for PBXProject "sharenote" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4AD9C7DB2E6987D400DE5C80 /* Debug */,
+				4AD9C7DC2E6987D400DE5C80 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		4AD9C7DD2E6987D400DE5C80 /* Build configuration list for PBXNativeTarget "sharenote" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4AD9C7DE2E6987D400DE5C80 /* Debug */,
+				4AD9C7DF2E6987D400DE5C80 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 4AD9C7C72E6987D300DE5C80 /* Project object */;
+}

--- a/mobile/ios/oxo-ios-ben3/src/sharenote/sharenote/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/mobile/ios/oxo-ios-ben3/src/sharenote/sharenote/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/mobile/ios/oxo-ios-ben3/src/sharenote/sharenote/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/mobile/ios/oxo-ios-ben3/src/sharenote/sharenote/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/mobile/ios/oxo-ios-ben3/src/sharenote/sharenote/Assets.xcassets/Contents.json
+++ b/mobile/ios/oxo-ios-ben3/src/sharenote/sharenote/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/mobile/ios/oxo-ios-ben3/src/sharenote/sharenote/ContentView.swift
+++ b/mobile/ios/oxo-ios-ben3/src/sharenote/sharenote/ContentView.swift
@@ -1,0 +1,56 @@
+// File: ContentView.swift
+import SwiftUI
+
+struct ContentView: View {
+    @EnvironmentObject var store: NoteStore
+    @State private var isShowingNewNoteSheet = false // Controls the presentation of the add sheet
+
+    var body: some View {
+        NavigationView {
+            List {
+                ForEach(store.notes) { note in
+                    NavigationLink {
+                        NoteDetailView(note: note)
+                    } label: {
+                        VStack(alignment: .leading) {
+                            Text(note.title)
+                                .font(.headline)
+                                .lineLimit(1)
+                            Text("Created: \(note.date.formatted(date: .abbreviated, time: .shortened))")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                }
+                .onDelete(perform: store.deleteNote) // Enable swipe-to-delete
+            }
+            .navigationTitle("ShareNote")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    EditButton() // Edit button to enable deletion
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button(action: { isShowingNewNoteSheet = true }) {
+                        Image(systemName: "plus")
+                    }
+                }
+            }
+            .sheet(isPresented: $isShowingNewNoteSheet) {
+                // This sheet will present the note creation view
+                NewNoteView(isPresented: $isShowingNewNoteSheet)
+            }
+            .overlay {
+                if store.notes.isEmpty {
+                    Text("No notes yet.\nTap the '+' to create one or share an .html file to this app.")
+                        .foregroundColor(.secondary)
+                        .multilineTextAlignment(.center)
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    ContentView()
+        .environmentObject(NoteStore())
+}

--- a/mobile/ios/oxo-ios-ben3/src/sharenote/sharenote/Info.plist
+++ b/mobile/ios/oxo-ios-ben3/src/sharenote/sharenote/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.html</string>
+			</array>
+			<key>CFBundleTypeName</key>
+			<string>HTML Document</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+		</dict>
+	</array>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
+</dict>
+</plist>

--- a/mobile/ios/oxo-ios-ben3/src/sharenote/sharenote/NewNoteView.swift
+++ b/mobile/ios/oxo-ios-ben3/src/sharenote/sharenote/NewNoteView.swift
@@ -1,0 +1,50 @@
+// File: NewNoteView.swift
+import SwiftUI
+
+struct NewNoteView: View {
+    @EnvironmentObject var store: NoteStore
+    @Binding var isPresented: Bool
+
+    // State for the new note's input fields
+    @State private var noteTitle = ""
+    @State private var noteContent = ""
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Section(header: Text("Note Info")) {
+                    TextField("Title", text: $noteTitle)
+                    TextField("HTML Content", text: $noteContent, axis: .vertical)
+                        .lineLimit(5...) // Allows multiline input
+                }
+
+                Section(header: Text("Preview")) {
+                    Text("Note preview will be shown when opened.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+            .navigationTitle("New Note")
+            .navigationBarItems(
+                leading: Button("Cancel") {
+                    isPresented = false
+                },
+                trailing: Button("Save") {
+                    saveNote()
+                }
+                .disabled(noteTitle.isEmpty || noteContent.isEmpty) // Don't allow saving empty notes
+            )
+        }
+    }
+
+    private func saveNote() {
+        // VULNERABILITY: We directly save the user's input without sanitization.
+        store.addNote(title: noteTitle, content: noteContent)
+        isPresented = false // Dismiss the sheet
+    }
+}
+
+#Preview {
+    NewNoteView(isPresented: .constant(true))
+        .environmentObject(NoteStore())
+}

--- a/mobile/ios/oxo-ios-ben3/src/sharenote/sharenote/Note.swift
+++ b/mobile/ios/oxo-ios-ben3/src/sharenote/sharenote/Note.swift
@@ -1,0 +1,15 @@
+// File: Note.swift
+import Foundation
+
+struct Note: Identifiable, Codable {
+    var id = UUID()
+    var title: String
+    var content: String
+    var date: Date
+
+    init(title: String, content: String, date: Date = Date()) {
+        self.title = title
+        self.content = content
+        self.date = date
+    }
+}

--- a/mobile/ios/oxo-ios-ben3/src/sharenote/sharenote/NoteDetailView.swift
+++ b/mobile/ios/oxo-ios-ben3/src/sharenote/sharenote/NoteDetailView.swift
@@ -1,0 +1,29 @@
+// File: NoteDetailView.swift
+import SwiftUI
+import WebKit
+
+struct WebView: UIViewRepresentable {
+    let htmlString: String
+    func makeUIView(context: Context) -> WKWebView { return WKWebView() }
+    func updateUIView(_ uiView: WKWebView, context: Context) {
+        // VULNERABILITY: Directly loading unsanitized HTML
+        let header = "<meta name='viewport' content='width=device-width, initial-scale=1.0'>"
+        let fullHTML = header + htmlString
+        uiView.loadHTMLString(fullHTML, baseURL: nil)
+    }
+}
+
+struct NoteDetailView: View {
+    let note: Note
+    var body: some View {
+        WebView(htmlString: note.content)
+            .navigationTitle(note.title)
+            .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+#Preview {
+    NavigationView {
+        NoteDetailView(note: Note(title: "Test", content: "<h1>Test</h1>"))
+    }
+}

--- a/mobile/ios/oxo-ios-ben3/src/sharenote/sharenote/NoteStore.swift
+++ b/mobile/ios/oxo-ios-ben3/src/sharenote/sharenote/NoteStore.swift
@@ -1,0 +1,40 @@
+// File: NoteStore.swift
+import Foundation
+
+class NoteStore: ObservableObject {
+    @Published var notes: [Note] = [] {
+        didSet {
+            saveNotes()
+        }
+    }
+
+    init() {
+        loadNotes()
+    }
+
+    // Save notes to UserDefaults
+    private func saveNotes() {
+        if let encoded = try? JSONEncoder().encode(notes) {
+            UserDefaults.standard.set(encoded, forKey: "SavedNotes")
+        }
+    }
+
+    // Load notes from UserDefaults
+    private func loadNotes() {
+        if let data = UserDefaults.standard.data(forKey: "SavedNotes"),
+           let decoded = try? JSONDecoder().decode([Note].self, from: data) {
+            notes = decoded
+        }
+    }
+
+    // Function to add a new note
+    func addNote(title: String, content: String) {
+        let newNote = Note(title: title, content: content)
+        notes.insert(newNote, at: 0) // Add new notes at the top of the list
+    }
+
+    // Function to delete a note
+    func deleteNote(at offsets: IndexSet) {
+        notes.remove(atOffsets: offsets)
+    }
+}

--- a/mobile/ios/oxo-ios-ben3/src/sharenote/sharenote/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/mobile/ios/oxo-ios-ben3/src/sharenote/sharenote/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/mobile/ios/oxo-ios-ben3/src/sharenote/sharenote/sharenoteApp.swift
+++ b/mobile/ios/oxo-ios-ben3/src/sharenote/sharenote/sharenoteApp.swift
@@ -1,0 +1,34 @@
+// File: ShareNoteApp.swift
+import SwiftUI
+
+@main
+struct ShareNoteApp: App {
+    @StateObject private var store = NoteStore()
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environmentObject(store)
+                .onOpenURL { url in
+                    handleIncomingFile(url: url)
+                }
+        }
+    }
+
+    func handleIncomingFile(url: URL) {
+        guard url.pathExtension == "html" else { return }
+        do {
+            let htmlContent = try String(contentsOf: url, encoding: .utf8)
+            let newNote = Note(
+                title: url.deletingPathExtension().lastPathComponent,
+                content: htmlContent // VULNERABILITY: Storing raw HTML
+            )
+            // Add to the store, which will automatically save it
+            store.notes.insert(newNote, at: 0)
+            print("Imported note from: \(url.lastPathComponent)")
+
+        } catch {
+            print("Failed to import file: \(error)")
+        }
+    }
+}


### PR DESCRIPTION
# oxo-ios-ben3 ShareNote - iOS Stored XSS

## Challenge Details

### Description
A seemingly innocuous note-sharing application for iOS, "ShareNote," allows users to create notes from HTML content or import `.html` files from other applications. The application fails to sanitize user-controlled HTML input before rendering it in a privileged WebView context, creating a classic injection vulnerability. Can your tool identify the data exfiltration path?

### Vulnerability Type and Category
- **Type:** Stored Cross-Site Scripting (XSS)
- **Category:** Injection

### Weakness (CWE)
- **CWE-79:** Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')

### Platform
iOS (Swift/SwiftUI)

### Difficulty
Medium

## Vulnerability Overview
The application's `NoteDetailView` renders note content by directly passing user-controlled input (from either manual creation or file import) to a `WKWebView`'s `loadHTMLString` method without any sanitization. This allows for the execution of arbitrary JavaScript code in the context of the application. The provided proof-of-concept payload demonstrates data exfiltration by leveraging an image's `onerror` event to send the device's User-Agent string to a remote server controlled by the attacker.

## Exploitation Vectors
1.  **File Import:** The app is registered to handle `.html` files. A malicious HTML file shared from Mail, Messages, or Safari will be imported and stored as a note.
2.  **Manual Creation:** The in-app note editor allows users to paste or write raw HTML content, which is stored without validation.

## Build Instructions
This is a standard Xcode project. Open `ShareNote.xcodeproj` and build for the iOS Simulator or a physical device.

1.  **Ensure your dummy server is running** to capture exfiltrated data (see `Server Setup` below).
2.  **Run the app** in the simulator (`Cmd + R`).
3.  **Trigger the vulnerability** by either:
    - Tapping the `+` button, creating a new note with HTML/JS content, saving it, and opening it.
    - Importing a malicious `.html` file into the app from another application (e.g., Safari, Files).


<img width="381" height="798" alt="Screenshot from 2025-09-04 10-43-00" src="https://github.com/user-attachments/assets/e59bb66d-0e22-475b-b344-68d18aea946d" />
