### PR TITLE
feature: Update CODEOWNERS with new readability team ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # This file is for defining the code owners for the repository.
 # See https://help.github.com/articles/about-code-owners/ for more information.
-* @Ostorlab/api-readability
+* @Ostorlab/security-readability 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# This file is for defining the code owners for the repository.
+# See https://help.github.com/articles/about-code-owners/ for more information.
+* @Ostorlab/api-readability


### PR DESCRIPTION
Updates .github/CODEOWNERS to enforce @Ostorlab/api-readability ownership.